### PR TITLE
Fix council voting

### DIFF
--- a/contracts/enterprise/src/contract.rs
+++ b/contracts/enterprise/src/contract.rs
@@ -705,7 +705,7 @@ fn cast_council_vote(ctx: &mut Context, msg: CastVoteMsg) -> DaoResult<Response>
                 .may_load(ctx.deps.storage, msg.proposal_id)?
                 .ok_or(NoSuchProposal)?;
 
-            if proposal_info.proposal_type != General {
+            if proposal_info.proposal_type != Council {
                 return Err(WrongProposalType);
             }
 


### PR DESCRIPTION
Council voting doesn't work right now, due to wrong enum value being used in the proposal type check.